### PR TITLE
Add blog post conversion

### DIFF
--- a/SiteGenerator.ConsoleApp/BlogPostConverter.cs
+++ b/SiteGenerator.ConsoleApp/BlogPostConverter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SiteGenerator.ConsoleApp.Models;
+using SiteGenerator.ConsoleApp.Models.Config;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using static SiteGenerator.ConsoleApp.UrlUtils;
+
+namespace SiteGenerator.ConsoleApp
+{
+    public class BlogPostConverter
+    {
+        private readonly TopLevelConfig topLevelConfig;
+        private readonly HandlebarsConverter handlebarsConverter;
+        private Config Config => topLevelConfig.Config;
+
+        public BlogPostConverter(TopLevelConfig topLevelConfig, HandlebarsConverter handlebarsConverter)
+        {
+            this.topLevelConfig = topLevelConfig;
+            this.handlebarsConverter = handlebarsConverter;
+        }
+
+        public PostModel ProcessBlogPost(string path)
+        {
+            PostModel post = ReadBlogPost(path);
+            ConvertToHtml(post);
+
+            return post;
+        }
+
+        public static PostModel ReadBlogPost(string path)
+        {
+            string blogPostWithFrontmatter = File.ReadAllText(path);
+
+            var parts = blogPostWithFrontmatter.Split("---" + Environment.NewLine, 2,
+                StringSplitOptions.RemoveEmptyEntries);
+
+            if (parts.Length != 2)
+            {
+                throw new PostFormatException(
+                    $"Blog post {path} is expected to contain exactly two parts, not {parts.Length}");
+            }
+
+            string frontmatterYaml = parts[0];
+            string blogPostBody = parts[1];
+
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(UnderscoredNamingConvention.Instance)
+                .Build();
+
+            var post = deserializer.Deserialize<PostModel>(frontmatterYaml);
+            post.Body = blogPostBody;
+            return post;
+        }
+
+        private void ConvertToHtml(PostModel post)
+        {
+            string layout = File.ReadAllText(Path.Join(topLevelConfig.Config.LayoutsDir, post.Layout + ".hbs"));
+
+            string result = handlebarsConverter.Convert(layout, new Dictionary<string, object>
+            {
+                {"post", post.ToDictionary()}
+            });
+
+            foreach (string postCategory in post.Categories)
+            {
+                string outputDir = Path.Join(Config.OutputDir, Slugify(postCategory), post.Date.Year.ToString(),
+                    post.Date.Month.ToString(), post.Date.Day.ToString(), Slugify(post.Title));
+                string outputPath = Path.Join(outputDir, "index.html");
+
+                Directory.CreateDirectory(outputDir);
+                File.WriteAllText(outputPath, result);
+            }
+        }
+    }
+}

--- a/SiteGenerator.ConsoleApp/Exceptions.cs
+++ b/SiteGenerator.ConsoleApp/Exceptions.cs
@@ -9,4 +9,12 @@ namespace SiteGenerator.ConsoleApp
         {
         }
     }
+
+    internal class PostFormatException : Exception
+    {
+        public PostFormatException(string message)
+            : base(message)
+        {
+        }
+    }
 }

--- a/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
+++ b/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
@@ -14,8 +14,9 @@ namespace SiteGenerator.ConsoleApp
     /// </summary>
     public class HandlebarsConverter
     {
-        private IHandlebars handlebars;
-        private TopLevelConfig topLevelConfig;
+        private readonly IHandlebars handlebars;
+        private readonly TopLevelConfig topLevelConfig;
+
         private Config Config => topLevelConfig.Config;
 
         public HandlebarsConverter(TopLevelConfig topLevelConfig)
@@ -29,7 +30,7 @@ namespace SiteGenerator.ConsoleApp
             handlebars.RegisterHelper("set", SetHelper);
         }
 
-        public string Convert(string source)
+        public string Convert(string source, IDictionary<string,object> extraData = null)
         {
             var template = handlebars.Compile(source);
 
@@ -37,6 +38,11 @@ namespace SiteGenerator.ConsoleApp
 
             data.Add("now", DateTime.Now);
             data.Add("site", topLevelConfig.Site);
+
+            foreach ((string key, object value) in extraData ?? new Dictionary<string, object>())
+            {
+                data.Add(key, value);
+            }
 
             return template(data);
         }

--- a/SiteGenerator.ConsoleApp/Models/Config/Config.cs
+++ b/SiteGenerator.ConsoleApp/Models/Config/Config.cs
@@ -3,5 +3,8 @@ namespace SiteGenerator.ConsoleApp.Models.Config
     public class Config
     {
         public string SourceDir { get; set; }
+        public string LayoutsDir { get; set; }
+        public string OutputDir { get; set; }
+        public string PostsDir { get; set; }
     }
 }

--- a/SiteGenerator.ConsoleApp/Models/PostModel.cs
+++ b/SiteGenerator.ConsoleApp/Models/PostModel.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using Markdig;
+using YamlDotNet.Serialization;
+using static SiteGenerator.ConsoleApp.UrlUtils;
+
+namespace SiteGenerator.ConsoleApp.Models
+{
+    [UsedImplicitly]
+    public class PostModel
+    {
+        [UsedImplicitly]
+        public string Title { get; set; }
+
+        [UsedImplicitly]
+        public DateTime Date { get; set; }
+
+        [UsedImplicitly]
+        public string[] Categories { get; set; }
+
+        [UsedImplicitly]
+        public string Layout { get; set; }
+
+        /// <summary>
+        /// Two-letter ISO-639-1 language code (e.g. sv, en, de etc)
+        /// </summary>
+        [UsedImplicitly]
+        public string Language { get; set; }
+
+        // Ignore this property as it will not be part of the YAML document
+        [YamlIgnore]
+        public string Body { get; set; }
+
+        private string Excerpt => Body.Split(Environment.NewLine + Environment.NewLine, 2).FirstOrDefault();
+
+        public IDictionary<string, object> ToDictionary()
+        {
+            // This is the "presentation layer" for this model object. The field names below are what the .hbs
+            // templates will see.
+            return new Dictionary<string, object>
+            {
+                {"date", Date.ToString("MMM d, yyyy")},
+                {"date_iso", Date.ToString("yyyy-MM-dd")},
+                {"excerpt", Markdown.ToHtml(Excerpt)},
+                {"title", Title},
+                {"body", Markdown.ToHtml(Body)},
+
+                {
+                    "link", Path.Join(
+                        "/",
+                        Slugify(Categories.First()),
+                        Date.Year.ToString(),
+                        Date.Month.ToString(),
+                        Date.Day.ToString(),
+                        Slugify(Title)
+                    )
+                },
+
+                {
+                    "categories", Categories.Select(c => new Dictionary<string, string>
+                    {
+                        {"name", c},
+                        {"slug", Slugify(c)}
+                    })
+                }
+            };
+        }
+    }
+}

--- a/SiteGenerator.ConsoleApp/Program.cs
+++ b/SiteGenerator.ConsoleApp/Program.cs
@@ -1,35 +1,72 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using SiteGenerator.ConsoleApp.Models;
 using SiteGenerator.ConsoleApp.Models.Config;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using static SiteGenerator.ConsoleApp.UrlUtils;
 
 namespace SiteGenerator.ConsoleApp
 {
     public class Program
     {
-        private HandlebarsConverter handlebarsConverter;
+        private readonly HandlebarsConverter handlebarsConverter;
+        private readonly Config config;
+        private readonly TopLevelConfig topLevelConfig;
+
+        /// <summary>
+        /// Returns a string representation of <see cref="DateTime.Now"/>, including milliseconds.
+        /// </summary>
+        private static string NowWithMillis => DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
 
         public static void Main(string[] args)
         {
-            if (args.Length != 2)
+            TopLevelConfig topLevelConfig = ReadConfig();
+            var program = new Program(topLevelConfig);
+
+            if (args[0] == "--post")
             {
-                Console.WriteLine("Syntax: sitegen --post <src-file> | <src-file> <target-file>");
+                var blogPostConverter = new BlogPostConverter(topLevelConfig, program.handlebarsConverter);
+
+                blogPostConverter.ProcessBlogPost(args[1]);
+            }
+            else if (args[0] == "--posts")
+            {
+                // Pass 1: convert all Markdown files to .html
+                var files = Directory.GetFiles(topLevelConfig.Config.PostsDir, "*.md");
+                var posts = program.ConvertPosts(files);
+
+                // Pass 2: generate category listings for all categories used by these posts.
+                program.CreateCategoryPages(posts);
+            }
+            else if (args.Length == 2)
+            {
+                string sourcePath = args[0];
+                string targetPath = args[1];
+
+                program.ConvertHandlebarsFile(sourcePath, targetPath);
+            }
+            else
+            {
+                Console.WriteLine(
+                    "Syntax: sitegen --post <src-file> | <src-file> <target-file> | --posts <src-file1> <src-file2> <...>");
                 Environment.Exit(1);
             }
+        }
 
-            TopLevelConfig config = ReadConfig();
-
-            string sourcePath = args[0];
-            string targetPath = args[1];
-
-            var program = new Program(config);
-            program.ConvertHandlebarsFile(sourcePath, targetPath);
+        private static void LogInfo(string message)
+        {
+            Console.WriteLine($"[{NowWithMillis}] {message}");
         }
 
         private Program(TopLevelConfig topLevelConfig)
         {
+            config = topLevelConfig.Config;
             handlebarsConverter = new HandlebarsConverter(topLevelConfig);
+
+            this.topLevelConfig = topLevelConfig;
         }
 
         private static TopLevelConfig ReadConfig()
@@ -51,6 +88,26 @@ namespace SiteGenerator.ConsoleApp
             // Set default values for config settings which have not been provided
             config.Config ??= new Config();
             config.Config.SourceDir ??= "src";
+            config.Config.LayoutsDir ??= Path.Join(config.Config.SourceDir, "_layouts");
+            config.Config.OutputDir ??= "out";
+            config.Config.PostsDir ??= "src/_posts";
+        }
+
+        private IEnumerable<PostModel> ConvertPosts(IEnumerable<string> files)
+        {
+            var posts = new List<PostModel>();
+
+            var blogPostConverter = new BlogPostConverter(topLevelConfig, handlebarsConverter);
+
+            foreach (string postSourceFile in files)
+            {
+                var post = blogPostConverter.ProcessBlogPost(postSourceFile);
+                LogInfo($"Converted {postSourceFile} to HTML");
+
+                posts.Add(post);
+            }
+
+            return posts;
         }
 
         /// <summary>
@@ -60,8 +117,58 @@ namespace SiteGenerator.ConsoleApp
         /// <param name="targetPath">the path to the target .html file</param>
         private void ConvertHandlebarsFile(string sourcePath, string targetPath)
         {
+            var blogPosts = Directory.GetFiles(config.PostsDir, "*.md")
+                .Select(BlogPostConverter.ReadBlogPost)
+                .OrderByDescending(p => p.Date)
+                .Select(p => p.ToDictionary());
+
+            var extraData = new Dictionary<string, object>
+            {
+                {"blog_posts", blogPosts}
+            };
+
             string source = File.ReadAllText(sourcePath);
-            string result = handlebarsConverter.Convert(source);
+            string result = handlebarsConverter.Convert(source, extraData);
+
+            File.WriteAllText(targetPath, result);
+        }
+
+        private void CreateCategoryPages(IEnumerable<PostModel> allPosts)
+        {
+            var postsByCategory = new Dictionary<string, List<PostModel>>();
+
+            foreach (PostModel postModel in allPosts)
+            {
+                foreach (string category in postModel.Categories)
+                {
+                    if (!postsByCategory.ContainsKey(category))
+                    {
+                        postsByCategory[category] = new List<PostModel>();
+                    }
+
+                    postsByCategory[category].Add(postModel);
+                }
+            }
+
+            foreach ((string category, var categoryPosts) in postsByCategory)
+            {
+                WriteCategoryPage(category, categoryPosts);
+            }
+        }
+
+        private void WriteCategoryPage(string category, List<PostModel> categoryPosts)
+        {
+            string sourcePath = Path.Join(config.LayoutsDir, "category_archive.hbs");
+            string targetPath = Path.Join(config.OutputDir, Slugify(category), "index.html");
+
+            var extraData = new Dictionary<string, object>
+            {
+                {"category_posts", categoryPosts.Select(p => p.ToDictionary())},
+                {"category_name", category}
+            };
+
+            string source = File.ReadAllText(sourcePath);
+            string result = handlebarsConverter.Convert(source, extraData);
 
             File.WriteAllText(targetPath, result);
         }

--- a/SiteGenerator.ConsoleApp/SiteGenerator.ConsoleApp.csproj
+++ b/SiteGenerator.ConsoleApp/SiteGenerator.ConsoleApp.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Handlebars.Net" Version="1.10.1" />
+      <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
       <PackageReference Include="Markdig" Version="0.20.0" />
       <PackageReference Include="YamlDotNet" Version="8.1.2" />
     </ItemGroup>

--- a/SiteGenerator.ConsoleApp/UrlUtils.cs
+++ b/SiteGenerator.ConsoleApp/UrlUtils.cs
@@ -1,0 +1,22 @@
+namespace SiteGenerator.ConsoleApp
+{
+    public class UrlUtils
+    {
+        public static string Slugify(string s) => s
+            .ToLower()
+
+            // The umlaut (åäö -> aao) conversion part of this is arguably very Swedish/Finnish-specific. Could we make it
+            // more generic somehow?
+            .Replace('å', 'a')
+            .Replace('ä', 'a')
+            .Replace('ö', 'o')
+
+            // Dashes work better than spaces in URLs.
+            .Replace(' ', '-')
+
+            // We consider certain characters "forbidden" or unsuitable from being used in URLs; we simply strip them
+            // out when generating the slugs.
+            .Replace("!", "")
+            .Replace("?", "");
+    }
+}


### PR DESCRIPTION
- Convert blog posts to the appropriate files under `out/<category>`, creating non-existent folders as needed. The `--posts` parameter can be used to trigger this.
- Support generating an index of blog posts in `index.html`.
- Support generating indexes for each category. This is automatically taken care of when using `--posts`.