### PR TITLE
(many) Initial MVP of multi-language support

### DIFF
--- a/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
+++ b/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
@@ -49,6 +49,12 @@ namespace SiteGenerator.ConsoleApp.Models
 
         public IDictionary<string, object> ToDictionary(Config.Config config)
         {
+            string languagePrefix = config.MultipleLanguages switch
+            {
+                true => Language,
+                false => ""
+            };
+
             // This is the "presentation layer" for this model object. The field names below are what the .hbs
             // templates will see.
             return new Dictionary<string, object>
@@ -58,10 +64,12 @@ namespace SiteGenerator.ConsoleApp.Models
                 { "date_iso", Date.ToString("yyyy-MM-dd") },
                 { "body", MarkdownConverter.ToHtml(Body, LineBreaks ?? config.LineBreaks!.Value) },
                 { "excerpt", MarkdownConverter.ToHtml(Excerpt, LineBreaks ?? config.LineBreaks!.Value) },
+                { "language", Language },
 
                 {
                     "link", Path.Join(
                         "/",
+                        languagePrefix,
                         Slugify(Categories.First()),
                         Date.Year.ToString(),
                         Date.Month.ToString(),
@@ -73,11 +81,20 @@ namespace SiteGenerator.ConsoleApp.Models
                 {
                     "categories", Categories.Select(c => new Dictionary<string, string>
                     {
-                        {"name", c},
-                        {"slug", Slugify(c)}
+                        { "name", c },
+                        { "slug", Path.Join(languagePrefix, Slugify(c)) }
                     })
                 }
             };
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Title)}: {Title}, " +
+                   $"{nameof(Date)}: {Date}, " +
+                   $"{nameof(Categories)}: {Categories}, " +
+                   $"{nameof(Language)}: {Language}, " +
+                   $"{nameof(Excerpt)}: {Excerpt}";
         }
     }
 }

--- a/SiteGenerator.ConsoleApp/Models/Config/Config.cs
+++ b/SiteGenerator.ConsoleApp/Models/Config/Config.cs
@@ -7,5 +7,6 @@ namespace SiteGenerator.ConsoleApp.Models.Config
         public string OutputDir { get; set; }
         public string PostsDir { get; set; }
         public LineBreaks? LineBreaks { get; set; }
+        public bool MultipleLanguages { get; set; }
     }
 }

--- a/SiteGenerator.ConsoleApp/Services/CategoryPageCreator.cs
+++ b/SiteGenerator.ConsoleApp/Services/CategoryPageCreator.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using SiteGenerator.ConsoleApp.Models;
+using SiteGenerator.ConsoleApp.Models.Config;
+
+namespace SiteGenerator.ConsoleApp.Services
+{
+    internal abstract class CategoryPageCreator
+    {
+        protected Config Config { get; }
+
+        private readonly HandlebarsConverter handlebarsConverter;
+
+        protected CategoryPageCreator(Config config, HandlebarsConverter handlebarsConverter)
+        {
+            this.handlebarsConverter = handlebarsConverter;
+
+            Config = config;
+        }
+
+        /// <summary>
+        /// Creates category pages for all the categories referred to in the provided list of blog posts.
+        /// </summary>
+        /// <param name="allPosts">An enumerable of blog posts.</param>
+        public abstract void CreateCategoryPages(IEnumerable<BlogPostModel> allPosts);
+
+        protected void WriteCategoryPage(string category, List<BlogPostModel> categoryPosts, string targetPath)
+        {
+            string sourcePath = Path.Join(Config.LayoutsDir, "category_archive.hbs");
+
+            var extraData = new Dictionary<string, object>
+            {
+                { "category_posts", categoryPosts.Select(p => p.ToDictionary(Config)) },
+                { "category_name", category }
+            };
+
+            string source = File.ReadAllText(sourcePath);
+            string result = handlebarsConverter.Convert(source, extraData);
+
+            File.WriteAllText(targetPath, result);
+        }
+    }
+}

--- a/SiteGenerator.ConsoleApp/Services/HandlebarsConverter.cs
+++ b/SiteGenerator.ConsoleApp/Services/HandlebarsConverter.cs
@@ -5,12 +5,11 @@ using System.IO;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
 using SiteGenerator.ConsoleApp.Models.Config;
-using SiteGenerator.ConsoleApp.Services;
 
-namespace SiteGenerator.ConsoleApp
+namespace SiteGenerator.ConsoleApp.Services
 {
     /// <summary>
-    /// Converts Handlebars (.hbs) content to HTML (.html)
+    /// Converts Handlebars (`.hbs`) content to HTML (`.html`)
     /// </summary>
     public class HandlebarsConverter
     {

--- a/SiteGenerator.ConsoleApp/Services/MultiLanguage/MultiLanguageCategoryPageCreator.cs
+++ b/SiteGenerator.ConsoleApp/Services/MultiLanguage/MultiLanguageCategoryPageCreator.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using SiteGenerator.ConsoleApp.Models;
+using SiteGenerator.ConsoleApp.Models.Config;
+using static SiteGenerator.ConsoleApp.UrlUtils;
+
+namespace SiteGenerator.ConsoleApp.Services.MultiLanguage
+{
+    /// <summary>
+    /// Implementation of <see cref="CategoryPageCreator"/> for multi-language scenarios.
+    ///
+    /// In multi-language scenarios, the category pages uses the language identifier as the prefix, before the category
+    /// slug.
+    /// </summary>
+    internal class MultiLanguageCategoryPageCreator : CategoryPageCreator
+    {
+        public MultiLanguageCategoryPageCreator(Config config, HandlebarsConverter handlebarsConverter) :
+            base(config, handlebarsConverter)
+        {
+        }
+
+        public override void CreateCategoryPages(IEnumerable<BlogPostModel> allPosts)
+        {
+            var postsByLanguageAndCategory = new Dictionary<string, Dictionary<string, List<BlogPostModel>>>();
+
+            // Pass 1: Loop over all blog posts and build up the required data model.
+            foreach (BlogPostModel postModel in allPosts)
+            {
+                var postsByCategory = postsByLanguageAndCategory.GetValueOrDefault(
+                    postModel.Language,
+                    new Dictionary<string, List<BlogPostModel>>()
+                );
+
+                if (!postsByLanguageAndCategory.ContainsKey(postModel.Language))
+                {
+                    postsByLanguageAndCategory[postModel.Language] = postsByCategory;
+                }
+
+                foreach (string category in postModel.Categories)
+                {
+                    if (!postsByCategory!.ContainsKey(category))
+                    {
+                        postsByCategory[category] = new List<BlogPostModel>();
+                    }
+
+                    postsByCategory[category].Add(postModel);
+                }
+            }
+
+            // Pass 2: Loop over the created data model and create the category pages for all language/category
+            // combinations in existence.
+            foreach (string language in postsByLanguageAndCategory.Keys)
+            {
+                var postsByCategory = postsByLanguageAndCategory[language];
+
+                foreach ((string category, var categoryPosts) in postsByCategory)
+                {
+                    string targetPath = Path.Join(
+                        Config.OutputDir,
+                        language,
+                        Slugify(category),
+                        "index.html"
+                    );
+
+                    WriteCategoryPage(category, categoryPosts, targetPath);
+                }
+            }
+        }
+    }
+}

--- a/SiteGenerator.ConsoleApp/Services/SingleLanguage/SingleLanguageCategoryPageCreator.cs
+++ b/SiteGenerator.ConsoleApp/Services/SingleLanguage/SingleLanguageCategoryPageCreator.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.IO;
+using SiteGenerator.ConsoleApp.Models;
+using SiteGenerator.ConsoleApp.Models.Config;
+using static SiteGenerator.ConsoleApp.UrlUtils;
+
+namespace SiteGenerator.ConsoleApp.Services.SingleLanguage
+{
+    /// <summary>
+    /// Implementation of <see cref="CategoryPageCreator"/> for multi-language scenarios.
+    ///
+    /// Single-language scenarios are simple; no language identifier is needed in the URLs, and the categories don't
+    /// need to be grouped by language.
+    /// </summary>
+    internal class SingleLanguageCategoryPageCreator : CategoryPageCreator
+    {
+        public SingleLanguageCategoryPageCreator(Config config, HandlebarsConverter handlebarsConverter) :
+            base(config, handlebarsConverter)
+        {
+        }
+
+        public override void CreateCategoryPages(IEnumerable<BlogPostModel> allPosts)
+        {
+            var postsByCategory = new Dictionary<string, List<BlogPostModel>>();
+
+            foreach (BlogPostModel postModel in allPosts)
+            {
+                foreach (string category in postModel.Categories)
+                {
+                    if (!postsByCategory.ContainsKey(category))
+                    {
+                        postsByCategory[category] = new List<BlogPostModel>();
+                    }
+
+                    postsByCategory[category].Add(postModel);
+                }
+            }
+
+            foreach ((string category, var categoryPosts) in postsByCategory)
+            {
+                string targetPath = Path.Join(
+                    Config.OutputDir,
+                    Slugify(category),
+                    "index.html"
+                );
+
+                WriteCategoryPage(category, categoryPosts, targetPath);
+            }
+        }
+    }
+}

--- a/SiteGenerator.ConsoleApp/UrlUtils.cs
+++ b/SiteGenerator.ConsoleApp/UrlUtils.cs
@@ -27,10 +27,9 @@ namespace SiteGenerator.ConsoleApp
             // is again sufficient.
             .Replace("--", "-")
 
-            .Replace(",", "")
-
             // We consider certain characters "forbidden" or unsuitable from being used in URLs; we simply strip them
             // out when generating the slugs.
+            .Replace(",", "")
             .Replace("!", "")
             .Replace("?", "")
             .Replace(":", "")


### PR DESCRIPTION
- The `blog_posts` variable has been changed to be a dictionary of blog  posts, grouped by language. To access the blog posts for a given  language, use e.g. `blog_posts.en` to access all English-language posts.

- For use cases where multi-linguality is not required, you can just use  `all_blog_posts` for simplicity. This variable contains all blog posts  for all languages in the system