### PR TITLE
Enable Markdig extensions

### DIFF
--- a/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
+++ b/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
@@ -6,6 +6,7 @@ using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
 using Markdig;
 using SiteGenerator.ConsoleApp.Models.Config;
+using SiteGenerator.ConsoleApp.Services;
 
 namespace SiteGenerator.ConsoleApp
 {
@@ -75,7 +76,7 @@ namespace SiteGenerator.ConsoleApp
             var stringWriter = new StringWriter();
             options.Template(stringWriter, context);
 
-            string html = Markdown.ToHtml(stringWriter.ToString());
+            string html = MarkdownConverter.ToHtml(stringWriter.ToString());
 
             writer.WriteSafeString(html);
         }

--- a/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
+++ b/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
-using Markdig;
+using SiteGenerator.ConsoleApp.Services;
 using YamlDotNet.Serialization;
 using static SiteGenerator.ConsoleApp.UrlUtils;
 
@@ -50,11 +50,11 @@ namespace SiteGenerator.ConsoleApp.Models
             // templates will see.
             return new Dictionary<string, object>
             {
-                {"date", Date.ToString("MMM d, yyyy")},
-                {"date_iso", Date.ToString("yyyy-MM-dd")},
-                {"excerpt", Markdown.ToHtml(Excerpt)},
-                {"title", Title},
-                {"body", Markdown.ToHtml(Body)},
+                { "title", Title },
+                { "date", Date.ToString("MMM d, yyyy") },
+                { "date_iso", Date.ToString("yyyy-MM-dd") },
+                { "body", MarkdownConverter.ToHtml(Body) },
+                { "excerpt", MarkdownConverter.ToHtml(Excerpt) },
 
                 {
                     "link", Path.Join(

--- a/SiteGenerator.ConsoleApp/Services/MarkdownConverter.cs
+++ b/SiteGenerator.ConsoleApp/Services/MarkdownConverter.cs
@@ -1,0 +1,24 @@
+using Markdig;
+
+namespace SiteGenerator.ConsoleApp.Services
+{
+    public static class MarkdownConverter
+    {
+        /// <summary>
+        /// Converts the given Markdown text to HTML format.
+        ///
+        /// This method enables a number of Markdig extensions.
+        /// </summary>
+        /// <param name="markdown">The Markdown content</param>
+        /// <returns>An HTML representation of the given content.</returns>
+        public static string ToHtml(string markdown)
+        {
+            MarkdownPipeline pipeline = new MarkdownPipelineBuilder()
+                //.UseAdvancedExtensions()
+                .UseSoftlineBreakAsHardlineBreak()
+                .Build();
+
+            return Markdown.ToHtml(markdown, pipeline);
+        }
+    }
+}

--- a/SiteGenerator.sln.DotSettings
+++ b/SiteGenerator.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=frontmatter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ifeq/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Markdig/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sitegen/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
The following extensions are enabled by this change:

- `.UseAdvancedExtensions()`
- `.UseSoftlineBreakAsHardlineBreak()`

The latter does have a tendency to break existing blog posts. I will go through them and edit them in a separate commit to the `halleluja.nu` repo.

Note that the `UseSoftLineBreakAsHardlineBreak` can potentially be problematic, since this potentially deviates from what people expect from a Markdown parser. I think we should make this an opt-out flag that can you disable in either:

- `config.yaml`
- The YAML front-matter for an individual `.md` file

The config setting will serve as the global default, with the possibility to override this for an individual blog post. I will file an issue about this and link to it from here.