### PR TITLE
Make UseSoftLineBreakAsHardlineBreak configurable

### DIFF
--- a/SiteGenerator.ConsoleApp/BlogPostConverter.cs
+++ b/SiteGenerator.ConsoleApp/BlogPostConverter.cs
@@ -60,7 +60,7 @@ namespace SiteGenerator.ConsoleApp
 
             string result = handlebarsConverter.Convert(layout, new Dictionary<string, object>
             {
-                {"post", blogPost.ToDictionary()}
+                {"post", blogPost.ToDictionary(topLevelConfig.Config)}
             });
 
             foreach (string postCategory in blogPost.Categories)

--- a/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
+++ b/SiteGenerator.ConsoleApp/HandlebarsConverter.cs
@@ -4,7 +4,6 @@ using System.Dynamic;
 using System.IO;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
-using Markdig;
 using SiteGenerator.ConsoleApp.Models.Config;
 using SiteGenerator.ConsoleApp.Services;
 
@@ -70,13 +69,13 @@ namespace SiteGenerator.ConsoleApp
             writer.WriteSafeString(result);
         }
 
-        private static void MarkdownHelper(TextWriter writer, HelperOptions options, dynamic context,
+        private void MarkdownHelper(TextWriter writer, HelperOptions options, dynamic context,
             object[] arguments)
         {
             var stringWriter = new StringWriter();
             options.Template(stringWriter, context);
 
-            string html = MarkdownConverter.ToHtml(stringWriter.ToString());
+            string html = MarkdownConverter.ToHtml(stringWriter.ToString(), topLevelConfig.Config.LineBreaks!.Value);
 
             writer.WriteSafeString(html);
         }

--- a/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
+++ b/SiteGenerator.ConsoleApp/Models/BlogPostModel.cs
@@ -38,13 +38,16 @@ namespace SiteGenerator.ConsoleApp.Models
         [UsedImplicitly]
         public string Language { get; set; }
 
+        [UsedImplicitly]
+        public LineBreaks? LineBreaks { get; set; }
+
         // Ignore this property as it will not be part of the YAML document
         [YamlIgnore]
         public string Body { get; set; }
 
         private string Excerpt => Body.Split(Environment.NewLine + Environment.NewLine, 2).FirstOrDefault();
 
-        public IDictionary<string, object> ToDictionary()
+        public IDictionary<string, object> ToDictionary(Config.Config config)
         {
             // This is the "presentation layer" for this model object. The field names below are what the .hbs
             // templates will see.
@@ -53,8 +56,8 @@ namespace SiteGenerator.ConsoleApp.Models
                 { "title", Title },
                 { "date", Date.ToString("MMM d, yyyy") },
                 { "date_iso", Date.ToString("yyyy-MM-dd") },
-                { "body", MarkdownConverter.ToHtml(Body) },
-                { "excerpt", MarkdownConverter.ToHtml(Excerpt) },
+                { "body", MarkdownConverter.ToHtml(Body, LineBreaks ?? config.LineBreaks!.Value) },
+                { "excerpt", MarkdownConverter.ToHtml(Excerpt, LineBreaks ?? config.LineBreaks!.Value) },
 
                 {
                     "link", Path.Join(

--- a/SiteGenerator.ConsoleApp/Models/Config/Config.cs
+++ b/SiteGenerator.ConsoleApp/Models/Config/Config.cs
@@ -6,5 +6,6 @@ namespace SiteGenerator.ConsoleApp.Models.Config
         public string LayoutsDir { get; set; }
         public string OutputDir { get; set; }
         public string PostsDir { get; set; }
+        public LineBreaks? LineBreaks { get; set; }
     }
 }

--- a/SiteGenerator.ConsoleApp/Models/LineBreaks.cs
+++ b/SiteGenerator.ConsoleApp/Models/LineBreaks.cs
@@ -1,0 +1,8 @@
+namespace SiteGenerator.ConsoleApp.Models
+{
+    public enum LineBreaks
+    {
+        Soft,
+        Hard
+    }
+}

--- a/SiteGenerator.ConsoleApp/Program.cs
+++ b/SiteGenerator.ConsoleApp/Program.cs
@@ -117,6 +117,10 @@ namespace SiteGenerator.ConsoleApp
             config.Config.LayoutsDir ??= Path.Join(config.Config.SourceDir, "_layouts");
             config.Config.OutputDir ??= "out";
             config.Config.PostsDir ??= "src/_posts";
+
+            // Enabling "soft line breaks as hard" is currently the default. Can be opted out by individual blog posts
+            // as needed.
+            config.Config.LineBreaks ??= LineBreaks.Hard;
         }
 
         private void ConvertPosts()
@@ -247,7 +251,7 @@ namespace SiteGenerator.ConsoleApp
             var blogPosts = Directory.GetFiles(config.PostsDir, "*.md")
                 .Select(BlogPostConverter.ReadBlogPost)
                 .OrderByDescending(p => p.Date)
-                .Select(p => p.ToDictionary());
+                .Select(p => p.ToDictionary(topLevelConfig.Config));
 
             var extraData = new Dictionary<string, object>
             {
@@ -292,7 +296,7 @@ namespace SiteGenerator.ConsoleApp
 
             var extraData = new Dictionary<string, object>
             {
-                { "category_posts", categoryPosts.Select(p => p.ToDictionary()) },
+                { "category_posts", categoryPosts.Select(p => p.ToDictionary(topLevelConfig.Config)) },
                 { "category_name", category }
             };
 

--- a/SiteGenerator.ConsoleApp/Services/MarkdownConverter.cs
+++ b/SiteGenerator.ConsoleApp/Services/MarkdownConverter.cs
@@ -1,4 +1,5 @@
 using Markdig;
+using SiteGenerator.ConsoleApp.Models;
 
 namespace SiteGenerator.ConsoleApp.Services
 {
@@ -10,13 +11,18 @@ namespace SiteGenerator.ConsoleApp.Services
         /// This method enables a number of Markdig extensions.
         /// </summary>
         /// <param name="markdown">The Markdown content</param>
+        /// <param name="softLineBreaks">The LineBreaks setting.</param>
         /// <returns>An HTML representation of the given content.</returns>
-        public static string ToHtml(string markdown)
+        public static string ToHtml(string markdown, LineBreaks softLineBreaks)
         {
-            MarkdownPipeline pipeline = new MarkdownPipelineBuilder()
-                //.UseAdvancedExtensions()
-                .UseSoftlineBreakAsHardlineBreak()
-                .Build();
+            MarkdownPipelineBuilder pipelineBuilder = new MarkdownPipelineBuilder().UseAdvancedExtensions();
+
+            if (softLineBreaks == LineBreaks.Hard)
+            {
+                pipelineBuilder.UseSoftlineBreakAsHardlineBreak();
+            }
+
+            MarkdownPipeline pipeline = pipelineBuilder.Build();
 
             return Markdown.ToHtml(markdown, pipeline);
         }


### PR DESCRIPTION
I found an existing blog post (https://www.halleluja.nu/undervisning-fran-bibeln/2002/2/1/du-ar-gjord-till-rattfardighet-i-kristus-jesus/)
where it simply would make little sense to spend the time to remove hard line breaks just for the sake of it. It's better to tweak this in
`sitegen`, making it configurable so that individual blog posts can opt out from this behavior.

Closes #15.