### PR TITLE
(HandlebarsConverter) Use proper context in ifeq blocks

### DIFF
--- a/SiteGenerator.ConsoleApp/Services/HandlebarsConverter.cs
+++ b/SiteGenerator.ConsoleApp/Services/HandlebarsConverter.cs
@@ -132,11 +132,11 @@ namespace SiteGenerator.ConsoleApp.Services
 
             if (left == right)
             {
-                options.Template(output, null);
+                options.Template(output, context);
             }
             else
             {
-                options.Inverse(output, null);
+                options.Inverse(output, context);
             }
         }
     }


### PR DESCRIPTION
The previous approach would use a `null` context, but this feels very
unintuitive. It feels more reasonable to me to just propagate the parent
context to these blocks.