### PR TITLE
(all) Rename project and namespace

### DIFF
--- a/SiteGenerator.ConsoleApp/Models/LineBreaks.cs
+++ b/SiteGenerator.ConsoleApp/Models/LineBreaks.cs
@@ -1,8 +1,0 @@
-namespace SiteGenerator.ConsoleApp.Models
-{
-    public enum LineBreaks
-    {
-        Soft,
-        Hard
-    }
-}

--- a/sitegen.sln
+++ b/sitegen.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SiteGenerator.ConsoleApp", "SiteGenerator.ConsoleApp\SiteGenerator.ConsoleApp.csproj", "{A407BBF4-56E2-4720-80B0-D7B4AFD51F35}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitegen", "src\Sitegen\Sitegen.csproj", "{A407BBF4-56E2-4720-80B0-D7B4AFD51F35}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Sitegen/Exceptions.cs
+++ b/src/Sitegen/Exceptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace SiteGenerator.ConsoleApp
+namespace Sitegen
 {
     internal class ConfigurationException : Exception
     {

--- a/src/Sitegen/Models/BlogPostModel.cs
+++ b/src/Sitegen/Models/BlogPostModel.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
-using SiteGenerator.ConsoleApp.Services;
+using Sitegen.Services;
 using YamlDotNet.Serialization;
-using static SiteGenerator.ConsoleApp.UrlUtils;
+using static Sitegen.UrlUtils;
 
-namespace SiteGenerator.ConsoleApp.Models
+namespace Sitegen.Models
 {
     /// <summary>
     /// Representation of an individual blog post, as provided in an individual `.md` file.

--- a/src/Sitegen/Models/Config/Config.cs
+++ b/src/Sitegen/Models/Config/Config.cs
@@ -1,4 +1,4 @@
-namespace SiteGenerator.ConsoleApp.Models.Config
+namespace Sitegen.Models.Config
 {
     public class Config
     {

--- a/src/Sitegen/Models/Config/Site.cs
+++ b/src/Sitegen/Models/Config/Site.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 
-namespace SiteGenerator.ConsoleApp.Models.Config
+namespace Sitegen.Models.Config
 {
     public class Site
     {

--- a/src/Sitegen/Models/Config/TopLevelConfig.cs
+++ b/src/Sitegen/Models/Config/TopLevelConfig.cs
@@ -1,6 +1,6 @@
 using JetBrains.Annotations;
 
-namespace SiteGenerator.ConsoleApp.Models.Config
+namespace Sitegen.Models.Config
 {
     /// <summary>
     /// Top-level class used when deserializing `config.yaml` files.

--- a/src/Sitegen/Models/LineBreaks.cs
+++ b/src/Sitegen/Models/LineBreaks.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+
+namespace Sitegen.Models
+{
+    public enum LineBreaks
+    {
+        [UsedImplicitly]
+        Soft,
+
+        [UsedImplicitly]
+        Hard
+    }
+}

--- a/src/Sitegen/Program.cs
+++ b/src/Sitegen/Program.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using HandlebarsDotNet;
-using SiteGenerator.ConsoleApp.Models;
-using SiteGenerator.ConsoleApp.Models.Config;
-using SiteGenerator.ConsoleApp.Services;
-using SiteGenerator.ConsoleApp.Services.MultiLanguage;
-using SiteGenerator.ConsoleApp.Services.SingleLanguage;
+using Sitegen.Models;
+using Sitegen.Models.Config;
+using Sitegen.Services;
+using Sitegen.Services.MultiLanguage;
+using Sitegen.Services.SingleLanguage;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace SiteGenerator.ConsoleApp
+namespace Sitegen
 {
     /// <summary>
     /// Entry-point for `sitegen`. This is the main class, handling parsing of command line parameters and delegating

--- a/src/Sitegen/Services/BlogPostConverter.cs
+++ b/src/Sitegen/Services/BlogPostConverter.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using SiteGenerator.ConsoleApp.Models;
-using SiteGenerator.ConsoleApp.Models.Config;
+using Sitegen.Models;
+using Sitegen.Models.Config;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
-using static SiteGenerator.ConsoleApp.UrlUtils;
+using static Sitegen.UrlUtils;
 
-namespace SiteGenerator.ConsoleApp.Services
+namespace Sitegen.Services
 {
     public class BlogPostConverter
     {

--- a/src/Sitegen/Services/CategoryPageCreator.cs
+++ b/src/Sitegen/Services/CategoryPageCreator.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using SiteGenerator.ConsoleApp.Models;
-using SiteGenerator.ConsoleApp.Models.Config;
+using Sitegen.Models;
+using Sitegen.Models.Config;
 
-namespace SiteGenerator.ConsoleApp.Services
+namespace Sitegen.Services
 {
     internal abstract class CategoryPageCreator
     {

--- a/src/Sitegen/Services/HandlebarsConverter.cs
+++ b/src/Sitegen/Services/HandlebarsConverter.cs
@@ -4,9 +4,9 @@ using System.Dynamic;
 using System.IO;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
-using SiteGenerator.ConsoleApp.Models.Config;
+using Sitegen.Models.Config;
 
-namespace SiteGenerator.ConsoleApp.Services
+namespace Sitegen.Services
 {
     /// <summary>
     /// Converts Handlebars (`.hbs`) content to HTML (`.html`)

--- a/src/Sitegen/Services/MarkdownConverter.cs
+++ b/src/Sitegen/Services/MarkdownConverter.cs
@@ -1,7 +1,7 @@
 using Markdig;
-using SiteGenerator.ConsoleApp.Models;
+using Sitegen.Models;
 
-namespace SiteGenerator.ConsoleApp.Services
+namespace Sitegen.Services
 {
     public static class MarkdownConverter
     {

--- a/src/Sitegen/Services/MultiLanguage/MultiLanguageCategoryPageCreator.cs
+++ b/src/Sitegen/Services/MultiLanguage/MultiLanguageCategoryPageCreator.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
-using SiteGenerator.ConsoleApp.Models;
-using SiteGenerator.ConsoleApp.Models.Config;
-using static SiteGenerator.ConsoleApp.UrlUtils;
+using Sitegen.Models;
+using Sitegen.Models.Config;
+using static Sitegen.UrlUtils;
 
-namespace SiteGenerator.ConsoleApp.Services.MultiLanguage
+namespace Sitegen.Services.MultiLanguage
 {
     /// <summary>
     /// Implementation of <see cref="CategoryPageCreator"/> for multi-language scenarios.

--- a/src/Sitegen/Services/SingleLanguage/SingleLanguageCategoryPageCreator.cs
+++ b/src/Sitegen/Services/SingleLanguage/SingleLanguageCategoryPageCreator.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.IO;
-using SiteGenerator.ConsoleApp.Models;
-using SiteGenerator.ConsoleApp.Models.Config;
-using static SiteGenerator.ConsoleApp.UrlUtils;
+using Sitegen.Models;
+using Sitegen.Models.Config;
+using static Sitegen.UrlUtils;
 
-namespace SiteGenerator.ConsoleApp.Services.SingleLanguage
+namespace Sitegen.Services.SingleLanguage
 {
     /// <summary>
     /// Implementation of <see cref="CategoryPageCreator"/> for multi-language scenarios.

--- a/src/Sitegen/Sitegen.csproj
+++ b/src/Sitegen/Sitegen.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
         <AssemblyName>sitegen</AssemblyName>
+        <RootNamespace>Sitegen</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Sitegen/UrlUtils.cs
+++ b/src/Sitegen/UrlUtils.cs
@@ -1,4 +1,4 @@
-namespace SiteGenerator.ConsoleApp
+namespace Sitegen
 {
     public static class UrlUtils
     {


### PR DESCRIPTION
- `SiteGenerator` is overly long and complex. The project is de facto   called "sitegen", so let's just go wit that for now (in PascalCase).
- Likewise, `SiteGenerator.ConsoleApp` is a bit overly lengthy. Let's   remove the `ConsoleApp` suffix. This will play well with the   `Sitegen.Tests` project coming up shortly.